### PR TITLE
Add check when url of tapped story is null

### DIFF
--- a/HackerNews/HackerNews/Pages/NewsPage.cs
+++ b/HackerNews/HackerNews/Pages/NewsPage.cs
@@ -53,7 +53,10 @@ namespace HackerNews
                         PreferredToolbarColor = ColorConstants.BrowserNavigationBarBackgroundColor
                     };
 
-                    await Browser.OpenAsync(storyTapped.Url, browserOptions);
+                    if(!string.IsNullOrEmpty(storyTapped.Url))
+                        await Browser.OpenAsync(storyTapped.Url, browserOptions);
+                    else
+                        await DisplayAlert("Failed to open Browser", "This story has no url", "OK");
                 });
             }
         }


### PR DESCRIPTION
For stories which belong to [Ask HN : ..... ](https://github.com/HackerNews/API#items) category have their url's as null. Tapping on them crashes the app as `Browser.OpenAsync` requires a url which is not null.

![hn_crash](https://user-images.githubusercontent.com/14297705/67496413-00c7c780-f69a-11e9-849f-bf56c705217e.gif)

This PR adds a null check to prevent the crash.